### PR TITLE
fix: ensure pyinstaller platform-specific options are correctly applied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # 'platform' is just a convenience name.
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+          - os: macos-latest
+            platform: macos
 
     runs-on: ${{ matrix.os }}
-
 
     steps:
       - uses: actions/checkout@v4
@@ -52,33 +58,56 @@ jobs:
           # but no harm doing it twice.
           uv run ./scripts/generate_metadata.py
 
+      - name: extract version
+        id: get_version
+        shell: bash
+        run: |
+          found_version=$(uv run ./scripts/run.py --version | grep '^Version' | awk '{ print $2; }')
+          echo "version=$found_version" >> "$GITHUB_OUTPUT"
+
+      # windows build
+      # builds an exe at dist/yt-dlp-gui.exe
       - name: Build application windows
+        shell: bash
         if: runner.os == 'Windows'
         run: |
-          uv run pyinstaller --clean -y yt-dlp-gui.spec
+          set -x
+          make build-exe
+          version="${{ steps.get_version.outputs.version }}"
+          mv dist/yt-dlp-gui.exe dist/yt-dlp-gui-"${version}"-win.exe
 
+      # linux build
+      # builds a "onedir" version - a dir at dist/yt-dlp-gui
+      # TODO: cache/store the built docker image
+      # TODO: bundle the directory up into an AppImage
       - name: Build application ubuntu
         if: runner.os == 'Linux'
         run: |
+          set -x
           make docker-image-build
           make build-linux-exe
+          version="${{ steps.get_version.outputs.version }}"
+          cd dist
+          zip -r yt-dlp-gui-"${version}"-linux.zip yt-dlp-gui
 
+      # mac build
+      # builds an app "bundle" dir, at dist/yt-dlp-gui.app
+      # we zip it up into dist/yt-dlp-gui.app.zip
       - name: Build application macOS
         if: runner.os == 'macOS'
         run: |
+          set -x
           make build-exe
+          version="${{ steps.get_version.outputs.version }}"
+          cd dist
+          zip -r yt-dlp-gui-"${version}"-mac.zip yt-dlp-gui.app 
 
       - name: Upload artifact ${{ matrix.os }}
         uses: actions/upload-artifact@v4
         with:
           name: yt-dlp-gui-${{ matrix.os }}-Build-${{ github.run_number }}
-          path: ./dist/yt-dlp-gui
-
-      - name: Zip the build
-        shell: bash
-        run: |
-          cd dist
-          zip -r yt-dlp-gui-${{ runner.os }}.zip yt-dlp-gui
+          path: |
+            dist
 
       # for version tags only:
 
@@ -98,8 +127,32 @@ jobs:
           fi
 
 
-      - name: Create draft release
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Create draft release - Windows binary
+        if: runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Version ${{ github.ref_name }}"
+          tag_name: ${{ github.ref }}
+          generate_release_notes: true
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: dist/yt-dlp-gui*.exe
+      
+      - name: Create draft release - macOS app bundle
+        if: runner.os == 'macOS'  && startsWith(github.ref, 'refs/tags/v') 
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Version ${{ github.ref_name }}"
+          tag_name: ${{ github.ref }}
+          generate_release_notes: true
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: dist/yt-dlp-gui*.zip
+      
+      - name: Create draft release - Linux zip
+        if: runner.os == 'Linux'  && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           name: "Version ${{ github.ref_name }}"
@@ -110,3 +163,5 @@ jobs:
           files: |
             dist/yt-dlp-gui*.zip
           fail_on_unmatched_files: true
+
+      

--- a/yt-dlp-gui.spec
+++ b/yt-dlp-gui.spec
@@ -1,20 +1,11 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_all
 from PyInstaller.utils.hooks import copy_metadata
-
-# created using
-#
-#cmd=pyinstaller; \
-#	uv run $$cmd --onedir --name=yt-dlp-gui -y \
-#			--icon ./src/yt_dlp_gui/ui/assets/yt-dlp-gui.ico \
-#			--log-level DEBUG \
-#			--collect-all yt_dlp_gui \
-#			--copy-metadata yt_dlp_gui \
-#			--add-data "src/yt_dlp_gui/data/sample_config.toml:yt_dlp_gui/data" \
-#			--debug=all \
-#			--noupx \
-#			scripts/run.py
 import sys
+from pathlib import Path
+
+# TODO: we could, if desired, detect whether to enabled debugging (e.g. look for an env var,
+# `YTDL_PYINSTALLER_DEBUG`)
 
 datas = [('src/yt_dlp_gui/data/sample_config.toml', 'yt_dlp_gui/data')]
 binaries = []
@@ -23,14 +14,21 @@ datas += copy_metadata('yt_dlp_gui')
 tmp_ret = collect_all('yt_dlp_gui')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
-print("DATAS are:", datas, file=sys.stderr)
-print("tmp_ret are:", tmp_ret, file=sys.stderr)
+if sys.platform == 'darwin':
+    platform = 'mac'
+elif sys.platform.startswith('win'):
+    platform = 'windows'
+elif sys.platform.startswith('linux'):
+    platform = 'linux'
+else:
+    raise ValueError(f'unrecognized platform {sys.platform}')
 
-# change to True to debug built executable
-debug = True
+script_path = str(Path('scripts') / 'run.py')
+
+# perform analysis
 
 a = Analysis(
-    ['scripts/run.py'],
+    [script_path],
     pathex=[],
     binaries=binaries,
     datas=datas,
@@ -44,17 +42,32 @@ a = Analysis(
 )
 pyz = PYZ(a.pure)
 
+# build the exe
+
+if platform == "windows":
+  exec_params = [a.scripts, a.binaries, a.datas, [],]
+  exec_kws = {
+    'exclude_binaries': False,
+    'upx': True,
+    'upx_exclude': [],
+    'runtime_tmpdir': None,
+  }
+else:
+  exec_params = [a.scripts, []]
+  exec_kws = {
+    'exclude_binaries': True,
+    'upx': False,
+  }
+
 exe = EXE(
     pyz,
-    a.scripts,
-    [],
-    exclude_binaries=True,
+    *exec_params,
+    **exec_kws,
     name='yt-dlp-gui',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=False,
-    console=True,
+    console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
@@ -62,12 +75,30 @@ exe = EXE(
     entitlements_file=None,
     icon=['src/yt_dlp_gui/ui/assets/yt-dlp-gui.ico'],
 )
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.datas,
-    strip=False,
-    upx=False,
-    upx_exclude=[],
-    name='yt-dlp-gui',
-)
+
+# on windows - stop now.
+# on linux and mac - collect files needed for a "onedir" app
+
+if platform != 'windows':
+
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.datas,
+        strip=False,
+        upx=False,
+        upx_exclude=[],
+        name='yt-dlp-gui',
+    )
+
+# on mac only - build an app "bundle"
+
+if platform == "mac":
+    app = BUNDLE(
+        coll,
+        name='yt-dlp-gui.app',
+        icon=None,
+        bundle_identifier='com.github.phlummox-dev.yt-dlp-gui',
+    )
+
+# vim: syntax=python :


### PR DESCRIPTION
Fixes #1. If we generate .spec files on e.g. just linux, we don't end up with the correct configuration for a win or mac build.

And once correct artifacts are being built for each platform, include them in releases.